### PR TITLE
Explicitly Import Foundation

### DIFF
--- a/IXKeychain.h
+++ b/IXKeychain.h
@@ -9,6 +9,8 @@
 //	https://github.com/rackspace/rackspace-ios
 //
 
+#import <Foundation/Foundation.h>
+
 @interface Keychain : NSObject
 
 + (NSString *)serviceName;


### PR DESCRIPTION
In the old days with a prefix header, libraries like this didn't need to explicitly import things like UIKit or Foundation. 

Now that Xcode has kind of gotten rid of prefix headers, libraries like this won't work. This pull simply adds the Foundation import to allow it to work.
